### PR TITLE
Make `inspect` work with symbol primitives and objects, including in node 0.11 and 0.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ module.exports = function inspect_ (obj, opts, depth, seen) {
     else if (obj === null) {
         return 'null';
     }
+    else if (isSymbol(obj)) {
+        var symString = Symbol.prototype.toString.call(obj);
+        return typeof obj === 'object' ? 'Object(' + symString + ')' : symString;
+    }
     else if (isElement(obj)) {
         var s = '<' + String(obj.nodeName).toLowerCase();
         var attrs = obj.attributes || [];
@@ -95,6 +99,7 @@ function isArray (obj) { return toStr(obj) === '[object Array]' }
 function isDate (obj) { return toStr(obj) === '[object Date]' }
 function isRegExp (obj) { return toStr(obj) === '[object RegExp]' }
 function isError (obj) { return toStr(obj) === '[object Error]' }
+function isSymbol (obj) { return toStr(obj) === '[object Symbol]' }
 
 function has (obj, key) {
     if (!{}.hasOwnProperty) return key in obj;

--- a/test/values.js
+++ b/test/values.js
@@ -54,3 +54,10 @@ test('seen seen seen', function (t) {
         '[Circular]'
     );
 });
+
+test('symbols', { skip: typeof Symbol !== 'function' }, function (t) {
+	var sym = Symbol('foo');
+	t.equal(inspect(sym), 'Symbol(foo)', 'Symbol("foo") should be "Symbol(foo)"');
+	t.equal(inspect(Object(sym)), 'Object(Symbol(foo))', 'Object(Symbol("foo")) should be "Object(Symbol(foo))"');
+	t.end();
+});


### PR DESCRIPTION
In node `0.12`, `String(Symbol())` incorrectly throws an error.

This handles this case, by using `Symbol.prototype.toString.call` which doesn't throw in any engine.

(If this can be accepted and published, I'd love to see it bumped in `tape` as well, which will crash on node 0.12 when it attempts to inspect a Symbol value)