### PR TITLE
Add UMD support for use without a build step/via npmcdn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+object-inspect.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "string representations of objects in node and the browser",
   "main": "index.js",
   "devDependencies": {
+    "browserify": "^13.0.0",
     "tape": "^4.2.2"
   },
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "tape test/*.js",
+    "build-umd": "browserify index.js -o object-inspect.js --standalone inspect",
+    "release": "npm run build-umd && npm publish"
   },
   "testling": {
     "files": [


### PR DESCRIPTION
This simply adds a UMD build so the lib can be used from places like JSBin, via npmcdn.com

I also added a npm run release script to enable running the build as part of the publish process. I did not use prepublish since it runs on install as well.