### PR TITLE
[New] add support for inspecting String/Number/Boolean objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,7 @@ module.exports = function inspect_ (obj, opts, depth, seen) {
     
     var maxDepth = opts.depth === undefined ? 5 : opts.depth;
     if (depth === undefined) depth = 0;
-    if (depth >= maxDepth && maxDepth > 0
-    && obj && typeof obj === 'object') {
+    if (depth >= maxDepth && maxDepth > 0 && obj && typeof obj === 'object') {
         return '[Object]';
     }
     
@@ -95,7 +94,19 @@ module.exports = function inspect_ (obj, opts, depth, seen) {
         });
         return 'Set (' + setSize.call(obj) + ') {' + parts.join(', ') + '}';
     }
-    else if (typeof obj === 'object' && !isDate(obj) && !isRegExp(obj)) {
+    else if (typeof obj !== 'object') {
+        return String(obj);
+    }
+    else if (isNumber(obj)) {
+        return 'Object(' + Number(obj) + ')';
+    }
+    else if (isBoolean(obj)) {
+        return 'Object(' + !!obj + ')';
+    }
+    else if (isString(obj)) {
+        return 'Object(' + inspect(String(obj)) + ')';
+    }
+    else if (!isDate(obj) && !isRegExp(obj)) {
         var xs = [], keys = [];
         for (var key in obj) {
             if (has(obj, key)) keys.push(key);
@@ -123,6 +134,9 @@ function isDate (obj) { return toStr(obj) === '[object Date]' }
 function isRegExp (obj) { return toStr(obj) === '[object RegExp]' }
 function isError (obj) { return toStr(obj) === '[object Error]' }
 function isSymbol (obj) { return toStr(obj) === '[object Symbol]' }
+function isString (obj) { return toStr(obj) === '[object String]' }
+function isNumber (obj) { return toStr(obj) === '[object Number]' }
+function isBoolean (obj) { return toStr(obj) === '[object Boolean]' }
 
 var hasOwn = Object.prototype.hasOwnProperty || function (key) { return key in this; };
 function has (obj, key) {

--- a/test/values.js
+++ b/test/values.js
@@ -92,3 +92,30 @@ test('Set', { skip: typeof Set !== 'function' }, function (t) {
 
     t.end();
 });
+
+test('Strings', function (t) {
+    var str = 'abc';
+
+    t.equal(inspect(str), "'" + str + "'", 'primitive string shows as such');
+    t.equal(inspect(Object(str)), 'Object(' + inspect(str) + ')', 'String object shows as such');
+
+    t.end();
+});
+
+test('Numbers', function (t) {
+    var num = 42;
+
+    t.equal(inspect(num), String(num), 'primitive number shows as such');
+    t.equal(inspect(Object(num)), 'Object(' + inspect(num) + ')', 'Number object shows as such');
+
+    t.end();
+});
+
+test('Booleans', function (t) {
+    var bool = true;
+
+    t.equal(inspect(bool), String(bool), 'primitive boolean shows as such');
+    t.equal(inspect(Object(bool)), 'Object(' + inspect(bool) + ')', 'Boolean object shows as such');
+
+    t.end();
+});


### PR DESCRIPTION
Fixes #6.

I'm considering this a semver-minor: previously, `Number` and `Boolean` objects printed out as `{}` which is useless. `String` objects printed out as `{ 0: 'a', 1: 'b', 2: 'c' }` for example, and now print as `Object('abc')`, which I consider much more useful.

There's the potential this could be semver-major due to the `String` change, but I don't think that really applies to this module's use case.