### PR TITLE
Add type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+declare namespace objectInspect {
+  /**
+   * Inspection options
+   */
+  interface Options {
+    /**
+     * Maximum depth of the inspection. Default: `5`.
+     */
+    depth?: number;
+  }
+}
+
+/**
+ * Return a string `s` with the string representation of `obj` up to a depth of `opts.depth`.
+ *
+ * @param obj Object to inspect
+ * @param opts Inspection options. Default: `{}`.
+ * @return String representation of `obj`
+ */
+declare function objectInspect(obj: any, opts?: objectInspect.Options): string;
+
+export = objectInspect;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.0",
   "description": "string representations of objects in node and the browser",
   "main": "index.js",
+  "types": "index.d.ts",
   "devDependencies": {
     "core-js": "^2.5.1",
     "nyc": "^10.3.2",

--- a/readme.markdown
+++ b/readme.markdown
@@ -44,7 +44,7 @@ var inspect = require('object-inspect')
 ## var s = inspect(obj, opts={})
 
 Return a string `s` with the string representation of `obj` up to a depth of
-`opts.depth`.
+`opts.depth`. Default depth: `5`.
 
 # install
 


### PR DESCRIPTION
This commit add typescript type definitions. This allows Typescript
user to use this library out of the box. It also helps the editors
to provide auto-completion and quick documentation.

Closes substack/object-inspect#16