### PR TITLE
Add support for upcoming BigInt

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -4,8 +4,8 @@
   "instrumentation": false,
   "sourceMap": false,
   "reporter": "html",
-  "lines": 95.95,
-  "statements": 95,
+  "lines": 95.45,
+  "statements": 94.71,
   "functions": 96,
   "branches": 92,
   "exclude": [

--- a/.nycrc
+++ b/.nycrc
@@ -4,10 +4,10 @@
   "instrumentation": false,
   "sourceMap": false,
   "reporter": "html",
-  "lines": 95.45,
-  "statements": 94.71,
+  "lines": 94.94,
+  "statements": 94.25,
   "functions": 96,
-  "branches": 92,
+  "branches": 91.02,
   "exclude": [
     "coverage",
     "example",

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,15 @@ script:
   - 'if [ -n "${POSTTEST-}" ]; then npm run posttest ; fi'
   - 'if [ -n "${COVERAGE-}" ]; then npm run coverage ; fi'
   - 'if [ -n "${TEST-}" ]; then npm run tests-only ; fi'
+  - 'if [ -n "${BIGINT-}" ]; then npm run test:bigint ; fi'
 sudo: false
 env:
   - TEST=true
 matrix:
   fast_finish: true
   include:
+    - node_js: "10.0"
+      env: BIGINT=true
     - node_js: "node"
       env: COVERAGE=true
     - node_js: "9.10"

--- a/index.js
+++ b/index.js
@@ -38,6 +38,9 @@ module.exports = function inspect_ (obj, opts, depth, seen) {
       }
       return String(obj);
     }
+    if (typeof obj === 'bigint') {
+      return String(obj) + 'n';
+    }
 
     var maxDepth = typeof opts.depth === 'undefined' ? 5 : opts.depth;
     if (typeof depth === 'undefined') depth = 0;

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var setSize = hasSet && setSizeDescriptor && typeof setSizeDescriptor.get === 'f
 var setForEach = hasSet && Set.prototype.forEach;
 var booleanValueOf = Boolean.prototype.valueOf;
 var objectToString = Object.prototype.toString;
+var bigIntValueOf = typeof BigInt === 'function' ? BigInt.prototype.valueOf : null;
 
 var inspectCustom = require('./util.inspect').custom;
 var inspectSymbol = (inspectCustom && isSymbol(inspectCustom)) ? inspectCustom : null;
@@ -113,6 +114,9 @@ module.exports = function inspect_ (obj, opts, depth, seen) {
     if (isNumber(obj)) {
         return markBoxed(inspect(Number(obj)));
     }
+    if (isBigInt(obj)) {
+        return markBoxed(inspect(bigIntValueOf.call(obj)));
+    }
     if (isBoolean(obj)) {
         return markBoxed(booleanValueOf.call(obj));
     }
@@ -136,14 +140,15 @@ function quote (s) {
     return String(s).replace(/"/g, '&quot;');
 }
 
-function isArray (obj) { return toStr(obj) === '[object Array]' }
-function isDate (obj) { return toStr(obj) === '[object Date]' }
-function isRegExp (obj) { return toStr(obj) === '[object RegExp]' }
-function isError (obj) { return toStr(obj) === '[object Error]' }
-function isSymbol (obj) { return toStr(obj) === '[object Symbol]' }
-function isString (obj) { return toStr(obj) === '[object String]' }
-function isNumber (obj) { return toStr(obj) === '[object Number]' }
-function isBoolean (obj) { return toStr(obj) === '[object Boolean]' }
+function isArray (obj) { return toStr(obj) === '[object Array]'; }
+function isDate (obj) { return toStr(obj) === '[object Date]'; }
+function isRegExp (obj) { return toStr(obj) === '[object RegExp]'; }
+function isError (obj) { return toStr(obj) === '[object Error]'; }
+function isSymbol (obj) { return toStr(obj) === '[object Symbol]'; }
+function isString (obj) { return toStr(obj) === '[object String]'; }
+function isNumber (obj) { return toStr(obj) === '[object Number]'; }
+function isBigInt (obj) { return toStr(obj) === '[object BigInt]'; }
+function isBoolean (obj) { return toStr(obj) === '[object Boolean]'; }
 
 var hasOwn = Object.prototype.hasOwnProperty || function (key) { return key in this; };
 function has (obj, key) {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "scripts": {
     "test": "npm run tests-only",
+    "posttest": "npm run test:bigint",
     "pretests-only": "node test-core-js",
     "tests-only": "tape test/*.js",
+    "test:bigint": "node --harmony-bigint test/bigint",
     "coverage": "nyc npm run tests-only"
   },
   "testling": {

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,0 +1,10 @@
+var inspect = require('../');
+var test = require('tape');
+
+test('bigint', { skip: typeof BigInt === 'undefined' }, function (t) {
+  t.plan(3);
+
+  t.equal(inspect(BigInt(-256)), '-256n');
+  t.equal(inspect(BigInt(0)), '0n');
+  t.equal(inspect(BigInt(256)), '256n');
+});

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -2,9 +2,29 @@ var inspect = require('../');
 var test = require('tape');
 
 test('bigint', { skip: typeof BigInt === 'undefined' }, function (t) {
-  t.plan(3);
+  t.test('primitives', function (st) {
+    st.plan(3);
 
-  t.equal(inspect(BigInt(-256)), '-256n');
-  t.equal(inspect(BigInt(0)), '0n');
-  t.equal(inspect(BigInt(256)), '256n');
+    st.equal(inspect(BigInt(-256)), '-256n');
+    st.equal(inspect(BigInt(0)), '0n');
+    st.equal(inspect(BigInt(256)), '256n');
+  });
+
+  t.test('objects', function (st) {
+    st.plan(3);
+
+    st.equal(inspect(Object(BigInt(-256))), 'Object(-256n)');
+    st.equal(inspect(Object(BigInt(0))), 'Object(0n)');
+    st.equal(inspect(Object(BigInt(256))), 'Object(256n)');
+  });
+
+  t.test('syntactic primitives', function (st) {
+    st.plan(3);
+
+    st.equal(inspect(Function('return -256n')()), '-256n');
+    st.equal(inspect(Function('return 0n')()), '0n');
+    st.equal(inspect(Function('return 256n')()), '256n');
+  });
+
+  t.end();
 });


### PR DESCRIPTION
This feature is available in Node 10 behind a flag and in Chrome Canary. This change will not break runtimes that do not support BigInt.

I also took the liberty to add the `n` prefix, as you do in source code to create a BigInt, so there is a distinction between normal Number and BigInt.

This bug was found when tape printed `{}` for BigInts in assertions