### PR TITLE
Fix error in browsers not supporting Set

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,7 +200,7 @@ function isSet (x) {
         } catch (m) {
             return true;
         }
-        return x instanceof Set; // core-js workaround, pre-v2.5.0
+        return hasSet && x instanceof Set; // core-js workaround, pre-v2.5.0
     } catch (e) {}
     return false;
 }


### PR DESCRIPTION
Some older browsers not supporting Set won't catch this, but instead throw "Can't find variable Set". Specifically Safari 6 was tested.